### PR TITLE
Welcoming  our new maintainer and a few mix/ci-cd updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,17 @@ jobs:
       matrix:
         include:
           - pair:
-              elixir: '1.12'
-              otp: '22.3'
-              postgres: '12.13-alpine'
+              elixir: "1.11"
+              otp: "22.3"
+              postgres: "12.13-alpine"
           - pair:
-              elixir: '1.14'
-              otp: '25.2'
-              postgres: '15.1-alpine'
+              elixir: "1.12"
+              otp: "22.3"
+              postgres: "12.13-alpine"
+          - pair:
+              elixir: "1.14"
+              otp: "25.2"
+              postgres: "15.1-alpine"
             lint: lint
 
     runs-on: ubuntu-20.04

--- a/mix.exs
+++ b/mix.exs
@@ -80,8 +80,8 @@ defmodule CTE.MixProject do
         "mix.exs",
         "LICENSE"
       ],
-      licenses: ["Apache 2.0"],
-      maintainers: ["Florin T.PATRASCU"],
+      licenses: ["Apache-2.0"],
+      maintainers: ["Florin T.PATRASCU", "Greg Rychlewski"],
       links: %{
         "Docs" => @url_docs,
         "Github" => @url_github


### PR DESCRIPTION
we also included elixir 1.11 in the ci/cd matrix, because we recommend it as the minimum version in the mix. We also corrected the license name to get rid of the error message given by hex.pm, that of: license not recognized. 

And we have new maintainers, w⦿‿⦿t!! 

Greg, thanks for joining us, welcome!